### PR TITLE
Permit LineString shapefiles to be passed as ROI

### DIFF
--- a/src/EGMStoolkit/classes/EGMSS1ROIapi.py
+++ b/src/EGMStoolkit/classes/EGMSS1ROIapi.py
@@ -229,10 +229,10 @@ class S1ROIparameter:
         elif os.path.isfile(self.bbox):
             usermessage.egmstoolkitprint('Use the vector file giving by the user: %s' % (self.bbox),self.log,verbose)
             shape = fiona.open(self.bbox)
-            if shape.schema['geometry'] == 'MultiLineString':
+            if shape.schema['geometry'] == 'MultiLineString' or shape.schema['geometry'] == 'LineString':
                 gdal.VectorTranslate(self.workdirectory+os.sep+'bbox.shp',self.bbox,options='-f "ESRI Shapefile" -t_srs "EPSG:4326"')
             else: 
-                usermessage.egmstoolkitprint('\tThe shapefile is not a MultiLineString shape. It will be converted...',self.log,verbose)
+                usermessage.egmstoolkitprint('\tThe shapefile is neither a MultiLineString or LineString shape. It will be converted...',self.log,verbose)
 
                 with fiona.open(self.bbox) as roifile:   
                     listpts = []        


### PR DESCRIPTION
I noticed that LineString geometries are not permitted as Shapefile ROI. This is a problem because Fiona interprets the geometry schema as LineString even when the shapefile is created with a forced schema of MultiLineString. Even when using country codes the created bbox.shp has a geometry schema of LineString which in this case is not a problem because in the code this geometry schema is only checked when supplying a own Shapefile.

This PR allows LineString geometry Shapefiles to be used as ROI.